### PR TITLE
Parameterize JQ.reject

### DIFF
--- a/jq/src/main/java/se/code77/jq/JQ.java
+++ b/jq/src/main/java/se/code77/jq/JQ.java
@@ -311,14 +311,15 @@ public final class JQ {
 
     /**
      * Create a pre-rejected promise for the given exception
-     * 
+     *
+     * @param <T> Type of the value to be carried by the return promise
      * @param reason Exception to reject the promise with
      * @return A new promise
      */
-    public static Promise<Void> reject(final Exception reason) {
-        return defer(new DeferredHandler<Void>() {
+    public static <T> Promise<T> reject(final Exception reason) {
+        return defer(new DeferredHandler<T>() {
             @Override
-            public void handle(Deferred<Void> deferred) {
+            public void handle(Deferred<T> deferred) {
                 deferred.reject(reason);
             }
         });

--- a/jq/src/test/java/se/code77/jq/PromiseTests.java
+++ b/jq/src/test/java/se/code77/jq/PromiseTests.java
@@ -395,7 +395,7 @@ public class PromiseTests extends AsyncTests {
     @Test
     public void delay_isRejected() throws InterruptedException {
         // new promise is rejected immediately
-        Promise<Void> p = JQ.reject(TEST_REASON1).delay(1000);
+        Promise<Void> p = JQ.<Void>reject(TEST_REASON1).delay(1000);
 
         Thread.sleep(500);
         assertRejected(p, TEST_REASON1);


### PR DESCRIPTION
Allows creating a pre-rejected promise of any type, not just <Void>

Closes #5
