### PR TITLE
Dispatchers must be actively registered in Config

### DIFF
--- a/jq/build.gradle
+++ b/jq/build.gradle
@@ -7,10 +7,10 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 1
+        minSdkVersion 3
         targetSdkVersion 23
-        versionCode 6
-        versionName "1.0.5"
+        versionCode 7
+        versionName "1.0.6"
     }
     buildTypes {
     }

--- a/jq/src/main/java/se/code77/jq/PromiseImpl.java
+++ b/jq/src/main/java/se/code77/jq/PromiseImpl.java
@@ -247,7 +247,7 @@ class PromiseImpl<V> implements Promise<V> {
 
         mState = new StateSnapshot<>(State.FULFILLED, value, null);
         info("fulfilled with value '" + value + "'");
-        notify();
+        notifyAll();
         handleCompletion();
     }
 
@@ -256,7 +256,7 @@ class PromiseImpl<V> implements Promise<V> {
 
         mState = new StateSnapshot<>(State.REJECTED, null, reason);
         info("rejected with reason '" + reason + "'");
-        notify();
+        notifyAll();
         handleCompletion();
     }
 

--- a/jq/src/main/java/se/code77/jq/config/Config.java
+++ b/jq/src/main/java/se/code77/jq/config/Config.java
@@ -1,6 +1,9 @@
 
 package se.code77.jq.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import se.code77.jq.Promise;
 import se.code77.jq.config.android.AndroidConfig;
 
@@ -9,6 +12,8 @@ import se.code77.jq.config.android.AndroidConfig;
  * host environment, as well as tweaking of behaviour.
  */
 public abstract class Config {
+    protected final Map<Thread, Dispatcher> mDispatchers = new HashMap<>();
+
     /**
      * A dispatcher is capable of asynchronously dispatching events containing
      * code to be executed in a thread implementing an event loop. Each
@@ -139,8 +144,10 @@ public abstract class Config {
     public final boolean monitorUnterminated;
 
     /**
-     * Create a dispatcher capable of dispatching events to the current thread;
-     * or if the current thread does not implement an event loop, to another thread that does.
+     * Create a dispatcher for the current thread. Dispatchers are registered through
+     * #registterDispatcher(Thread, Dispatcher) but the exact behavior may differ for various
+     * Config implementations (e.g. there may be a default dispatcher, or the call may cause an
+     * error).
      * @return Dispatcher
      */
     public abstract Dispatcher createDispatcher();
@@ -150,5 +157,16 @@ public abstract class Config {
      * @return Logger
      */
     public abstract Logger getLogger();
+
+    /**
+     * Register a dispatcher for the given thread. Typically, any registered promise callbacks will
+     * be invoked on the dispatcher associated with the thread registering them, but the exact
+     * behavior may differ for various Config implementations.
+     * @param thread Thread
+     * @param dispatcher Dispatcher
+     */
+    public void registerDispatcher(Thread thread, Dispatcher dispatcher) {
+        mDispatchers.put(thread, dispatcher);
+    }
 
 }

--- a/jq/src/main/java/se/code77/jq/config/android/AndroidConfig.java
+++ b/jq/src/main/java/se/code77/jq/config/android/AndroidConfig.java
@@ -7,24 +7,22 @@ import android.os.Looper;
 import android.util.Log;
 
 public class AndroidConfig extends Config {
+    private final AndroidDispatcher mDefaultDispatcher;
+
     public AndroidConfig(boolean monitorUnterminated) {
-        super(monitorUnterminated);
+        this(monitorUnterminated, LogLevel.WARN);
     }
 
     public AndroidConfig(boolean monitorUnterminated, LogLevel logLevel) {
         super(monitorUnterminated, logLevel);
+
+        mDefaultDispatcher = new AndroidDispatcher(Looper.getMainLooper());
     }
 
     public static class AndroidDispatcher implements Dispatcher {
         protected final Handler mHandler;
 
-        public AndroidDispatcher() {
-            Looper looper = Looper.myLooper();
-
-            if (looper == null) {
-                looper = Looper.getMainLooper();
-            }
-
+        public AndroidDispatcher(Looper looper) {
             mHandler = new Handler(looper);
         }
 
@@ -90,7 +88,9 @@ public class AndroidConfig extends Config {
 
     @Override
     public Dispatcher createDispatcher() {
-        return new AndroidDispatcher();
+        Dispatcher d = mDispatchers.get(Thread.currentThread());
+
+        return d != null ? d : mDefaultDispatcher;
     }
 
     @Override


### PR DESCRIPTION
This eliminates deadlock problems in situations where worker threads are
mistakenly used as dispatchers.
