### PR TITLE
Promise.fail must return promise of the same type

### DIFF
--- a/jq/src/main/java/se/code77/jq/Promise.java
+++ b/jq/src/main/java/se/code77/jq/Promise.java
@@ -328,6 +328,7 @@ public interface Promise<V> extends Future<V> {
      * @return A new promise that will be resolved with the value
      *         returned/rejected with the reason thrown from any of the callback
      *         handlers.
+     * @throws NullPointerException if onFulfilled is null
      */
     public <NV> Promise<NV> then(
             OnFulfilledCallback<V, NV> onFulfilled, OnRejectedCallback<NV> onRejected, OnProgressedCallback onProgressed);
@@ -345,13 +346,14 @@ public interface Promise<V> extends Future<V> {
      * immediate execution in a future event loop turn, but will never be
      * inlined.
      * Note that this method MUST be run on a thread implementing an event loop.
-     * 
+     *
      * @param <NV> Type of the value returned by the callback handlers
      * @param onFulfilled Fulfillment handler
      * @param onRejected Rejection handler
      * @return A new promise that will be resolved with the value
      *         returned/rejected with the reason thrown from any of the callback
      *         handlers.
+     * @throws NullPointerException if onFulfilled is null
      */
     public <NV> Promise<NV> then(
             OnFulfilledCallback<V, NV> onFulfilled, OnRejectedCallback<NV> onRejected);
@@ -369,6 +371,7 @@ public interface Promise<V> extends Future<V> {
      * @return A new promise that will be resolved with the value
      *         returned/rejected with the reason thrown from the supplied
      *         callback handler.
+     * @throws NullPointerException if onFulfilled is null
      */
     public <NV> Promise<NV> then(OnFulfilledCallback<V, NV> onFulfilled);
 
@@ -387,6 +390,7 @@ public interface Promise<V> extends Future<V> {
      * @return A new promise that will be resolved with the value
      *         returned/rejected with the reason thrown from the supplied
      *         callback handler.
+     * @throws NullPointerException if onFulfilled is null
      */
     public <NV> Promise<NV> spread(
             OnFulfilledSpreadCallback<V, NV> onFulfilled, OnRejectedCallback<NV> onRejected);
@@ -405,6 +409,7 @@ public interface Promise<V> extends Future<V> {
      * @return A new promise that will be resolved with the value
      *         returned/rejected with the reason thrown from the supplied
      *         callback handler.
+     * @throws NullPointerException if onFulfilled is null
      */
     public <NV> Promise<NV> spread(OnFulfilledSpreadCallback<V, NV> onFulfilled);
 
@@ -417,12 +422,11 @@ public interface Promise<V> extends Future<V> {
      * 
      * @see #then(OnFulfilledCallback, OnRejectedCallback)
      * @param onRejected Rejection handler
-     * @param <NV> Type of the value returned by the callback handlers
      * @return A new promise that will be resolved with the value
      *         returned/rejected with the reason thrown from the supplied
      *         callback handler.
      */
-    public <NV> Promise<NV> fail(OnRejectedCallback<NV> onRejected);
+    public Promise<V> fail(OnRejectedCallback<V> onRejected);
 
     /**
      * Observe the progress of this promise by adding a progress callback which

--- a/jq/src/main/java/se/code77/jq/PromiseImpl.java
+++ b/jq/src/main/java/se/code77/jq/PromiseImpl.java
@@ -82,6 +82,10 @@ class PromiseImpl<V> implements Promise<V> {
     @Override
     public final <NV> Promise<NV> then(
             OnFulfilledCallback<V, NV> onFulfilled, OnRejectedCallback<NV> onRejected, OnProgressedCallback onProgressed) {
+        if (onFulfilled == null) {
+            throw new NullPointerException("Fulfilled handler must not be null");
+        }
+
         return addLink(onFulfilled, onRejected, onProgressed, false);
     }
     @Override
@@ -97,6 +101,10 @@ class PromiseImpl<V> implements Promise<V> {
 
     @Override
     public <NV> Promise<NV> spread(final OnFulfilledSpreadCallback<V, NV> onFulfilled, OnRejectedCallback<NV> onRejected) {
+        if (onFulfilled == null) {
+            throw new NullPointerException("Fulfilled handler must not be null");
+        }
+
         return then(new OnFulfilledCallback<V, NV>() {
             @Override
             public Future<NV> onFulfilled(V value) throws Exception {
@@ -136,13 +144,13 @@ class PromiseImpl<V> implements Promise<V> {
     }
 
     @Override
-    public final <NV> Promise<NV> fail(OnRejectedCallback<NV> onRejected) {
-        return then(null, onRejected);
+    public final Promise<V> fail(OnRejectedCallback<V> onRejected) {
+        return addLink(null, onRejected, null, false);
     }
 
     @Override
     public final Promise<V> progress(OnProgressedCallback onProgressed) {
-        return then(null, null, onProgressed);
+        return addLink(null, null, onProgressed, false);
     }
 
     @Override

--- a/jq/src/test/java/se/code77/jq/PromiseTests.java
+++ b/jq/src/test/java/se/code77/jq/PromiseTests.java
@@ -69,11 +69,16 @@ public class PromiseTests extends AsyncTests {
 
         // Test one-arg fail
         BlockingDataHolder<Exception> fail1 = new BlockingDataHolder<>();
-        p.fail(new DataRejectedCallback<>(fail1));
+        p.fail(new DataRejectedCallback<String>(fail1));
 
         // Test two-arg then
         BlockingDataHolder<Exception> fail2 = new BlockingDataHolder<>();
-        p.then(null, new DataRejectedCallback<>(fail2));
+        p.then(new OnFulfilledCallback<String, Void>() {
+            @Override
+            public Future<Void> onFulfilled(String value) throws Exception {
+                return null;
+            }
+        }, new DataRejectedCallback<Void>(fail2));
 
         deferred.reject(TEST_REASON1);
 


### PR DESCRIPTION
If not, an incosistency will occur if a then() follows a fail(), which
could cause a ClassCastException.

To avoid this, also adding NPE for null onFulfilled arguments for all
overloaded then() methods.

This fixes #19
