### PR TITLE
Void value

### DIFF
--- a/jq/build.gradle
+++ b/jq/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 3
         targetSdkVersion 23
-        versionCode 13
-        versionName "1.1.2"
+        versionCode 14
+        versionName "1.1.3"
     }
     buildTypes {
     }

--- a/jq/src/main/java/se/code77/jq/JQ.java
+++ b/jq/src/main/java/se/code77/jq/JQ.java
@@ -28,6 +28,11 @@ import se.code77.jq.Promise.StateSnapshot;
  * static counterparts to most instance methods on {@link Promise}.
  */
 public final class JQ {
+    /**
+     * Return value for Void callbacks
+     */
+    public static final Future<Void> VOID = null;
+
     private static final ExecutorService DEFAULT_EXECUTOR = Executors.newCachedThreadPool();
 
     /**


### PR DESCRIPTION
Adding JQ.VOID to be used from OnFulfilledCallback<Void> to help the compiler with type information. If simply returning null, and using lambda syntax, the compiler assumes the type to be Object.