### PR TITLE
Improved rejection stack traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 /build
 /captures
+/projectFilesBackup

--- a/jq/build.gradle
+++ b/jq/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 3
         targetSdkVersion 23
-        versionCode 18
-        versionName "1.1.7"
+        versionCode 19
+        versionName "1.1.8"
     }
     buildTypes {
     }

--- a/jq/src/main/java/se/code77/jq/JQ.java
+++ b/jq/src/main/java/se/code77/jq/JQ.java
@@ -101,7 +101,7 @@ public final class JQ {
          * @param reason Exception to reject the promise with
          */
         public void reject(Exception reason) {
-            ((PromiseImpl<V>) promise)._reject(reason, PromiseImpl.RejectionSource.DEFERRED);
+            ((PromiseImpl<V>) promise)._reject(reason, new PromiseImpl.RejectionInfo(PromiseImpl.RejectionInfo.Source.DEFERRED));
         }
 
         /**

--- a/jq/src/main/java/se/code77/jq/JQ.java
+++ b/jq/src/main/java/se/code77/jq/JQ.java
@@ -83,13 +83,13 @@ public final class JQ {
             p.then(new OnFulfilledCallback<V, Void>() {
                 @Override
                 public Future<Void> onFulfilled(V value) throws Exception {
-                    ((PromiseImpl<V>) promise)._resolve(value);
+                    resolve(value);
                     return null;
                 }
             }, new OnRejectedCallback<Void>() {
                 @Override
                 public Future<Void> onRejected(Exception reason) throws Exception {
-                    ((PromiseImpl<V>) promise)._reject(reason);
+                    reject(reason);
                     return null;
                 }
             }).done();
@@ -101,7 +101,7 @@ public final class JQ {
          * @param reason Exception to reject the promise with
          */
         public void reject(Exception reason) {
-            ((PromiseImpl<V>) promise)._reject(reason);
+            ((PromiseImpl<V>) promise)._reject(reason, PromiseImpl.RejectionSource.DEFERRED);
         }
 
         /**

--- a/jq/src/test/java/se/code77/jq/JQTests.java
+++ b/jq/src/test/java/se/code77/jq/JQTests.java
@@ -34,7 +34,7 @@ public class JQTests extends AsyncTests {
 
     @Test
     public void reject_isRejected() throws InterruptedException {
-        Promise<Void> p = JQ.reject(TEST_REASON1);
+        Promise<Void> p = JQ.reject(newReason(TEST_REASON1));
         TestConfig.waitForIdle();
         assertRejected(p, TEST_REASON1);
     }
@@ -63,7 +63,7 @@ public class JQTests extends AsyncTests {
     @Test
     public void all_isRejected() throws InterruptedException {
         Promise<List<String>> p = JQ.all(
-                JQ.resolve(TEST_VALUE1), JQ.defer(new SlowTask<String>(TEST_REASON1, 1000)));
+                JQ.resolve(TEST_VALUE1), JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 1000)));
 
         Thread.sleep(500);
         assertPending(p);
@@ -75,7 +75,7 @@ public class JQTests extends AsyncTests {
     public void all_isPending() throws InterruptedException {
         // at least one promise is not done -> resulting is pending forever
         Promise<List<String>> p = JQ.all(
-                JQ.defer(new SlowTask<>(TEST_VALUE1, 1000)), JQ.defer(new SlowTask<String>(TEST_REASON1, 2000)));
+                JQ.defer(new SlowTask<>(TEST_VALUE1, 1000)), JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 2000)));
 
         Thread.sleep(500);
         assertPending(p);
@@ -97,7 +97,7 @@ public class JQTests extends AsyncTests {
         Promise<String> p = JQ.any(
                 Arrays.asList(
                         JQ.defer(new SlowTask<>(TEST_VALUE1, 200)),
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 100))));
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 100))));
 
         Thread.sleep(500);
         assertResolved(p, TEST_VALUE1);
@@ -118,7 +118,7 @@ public class JQTests extends AsyncTests {
     public void any_isResolvedByLastAfterOtherRejected() throws InterruptedException {
         Promise<String> p = JQ.any(
                 Arrays.asList(
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 100)),
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 100)),
                         JQ.defer(new SlowTask<>(TEST_VALUE1, 200))));
 
         Thread.sleep(500);
@@ -129,8 +129,8 @@ public class JQTests extends AsyncTests {
     public void any_isRejected() throws InterruptedException {
         Promise<String> p = JQ.any(
                 Arrays.asList(
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 100)),
-                        JQ.defer(new SlowTask<String>(TEST_REASON2, 200))));
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 100)),
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON2), 200))));
 
         Thread.sleep(500);
         assertRejected(p);
@@ -173,7 +173,7 @@ public class JQTests extends AsyncTests {
     public void race_isRejectedByFirst() throws InterruptedException {
         Promise<String> p = JQ.race(
                 Arrays.asList(
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 100)),
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 100)),
                         JQ.defer(new SlowTask<>(TEST_VALUE1, 1000))));
 
         Thread.sleep(500);
@@ -185,7 +185,7 @@ public class JQTests extends AsyncTests {
         Promise<String> p = JQ.race(
                 Arrays.asList(
                         JQ.defer(new SlowTask<>(TEST_VALUE1, 1000)),
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 100))));
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 100))));
 
         Thread.sleep(500);
         assertRejected(p, TEST_REASON1);
@@ -223,8 +223,8 @@ public class JQTests extends AsyncTests {
         Promise<List<StateSnapshot<String>>> p = JQ.allSettled(
                 Arrays.asList(
                         JQ.defer(new SlowTask<>(TEST_VALUE1, 100)),
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 200)),
-                        JQ.defer(new SlowTask<String>(TEST_REASON2, 1000))));
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 200)),
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON2), 1000))));
 
         Thread.sleep(500);
         assertPending(p);
@@ -232,24 +232,24 @@ public class JQTests extends AsyncTests {
         Thread.sleep(1000);
         assertResolved(p, Arrays.asList(
                 new StateSnapshot<>(State.FULFILLED, TEST_VALUE1, null),
-                new StateSnapshot<String>(State.REJECTED, null, TEST_REASON1),
-                new StateSnapshot<String>(State.REJECTED, null, TEST_REASON2)));
+                new StateSnapshot<String>(State.REJECTED, null, newReason(TEST_REASON1)),
+                new StateSnapshot<String>(State.REJECTED, null, newReason(TEST_REASON2))));
     }
 
     @Test
     public void allSettled_isResolvedAllRejected() throws InterruptedException {
         Promise<List<StateSnapshot<String>>> p = JQ.allSettled(
                 Arrays.asList(
-                        JQ.defer(new SlowTask<String>(TEST_REASON1, 100)),
-                        JQ.defer(new SlowTask<String>(TEST_REASON2, 1000))));
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 100)),
+                        JQ.defer(new SlowTask<String>(newReason(TEST_REASON2), 1000))));
 
         Thread.sleep(500);
         assertPending(p);
 
         Thread.sleep(1000);
         assertResolved(p, Arrays.asList(
-                new StateSnapshot<String>(State.REJECTED, null, TEST_REASON1),
-                new StateSnapshot<String>(State.REJECTED, null, TEST_REASON2)));
+                new StateSnapshot<String>(State.REJECTED, null, newReason(TEST_REASON1)),
+                new StateSnapshot<String>(State.REJECTED, null, newReason(TEST_REASON2))));
     }
 
     @Test
@@ -304,7 +304,7 @@ public class JQTests extends AsyncTests {
 
     @Test
     public void wrap_isRejectedForFutureTaskFailedWithException() throws InterruptedException {
-        FutureTask<String> future = new FutureTask<>(new SlowTask<String>(TEST_REASON1, 1000));
+        FutureTask<String> future = new FutureTask<>(new SlowTask<String>(newReason(TEST_REASON1), 1000));
         Executors.newSingleThreadExecutor().execute(future);
 
         Promise<String> p = JQ.wrap(future);

--- a/jq/src/test/java/se/code77/jq/PromiseTests.java
+++ b/jq/src/test/java/se/code77/jq/PromiseTests.java
@@ -81,10 +81,10 @@ public class PromiseTests extends AsyncTests {
             }
         }, new DataRejectedCallback<Void>(fail2));
 
-        deferred.reject(TEST_REASON1);
+        deferred.reject(newReason(TEST_REASON1));
 
-        assertData(fail1, 2000, TEST_REASON1);
-        assertData(fail2, 2000, TEST_REASON1);
+        assertData(fail1, 2000, newReason(TEST_REASON1));
+        assertData(fail2, 2000, newReason(TEST_REASON1));
         assertRejected(p, TEST_REASON1);
     }
 
@@ -101,12 +101,12 @@ public class PromiseTests extends AsyncTests {
 
     @Test
     public void preRejected_isRejected() throws Exception {
-        Promise<Void> p = JQ.reject(TEST_REASON1);
+        Promise<Void> p = JQ.reject(newReason(TEST_REASON1));
 
         BlockingDataHolder<Exception> fail1 = new BlockingDataHolder<>();
         p.fail(new DataRejectedCallback<>(fail1));
 
-        assertData(fail1, 2000, TEST_REASON1);
+        assertData(fail1, 2000, newReason(TEST_REASON1));
         assertRejected(p, TEST_REASON1);
     }
 
@@ -122,7 +122,7 @@ public class PromiseTests extends AsyncTests {
 
     @Test
     public void rejected_isNotResolved() {
-        Promise<Void> p = JQ.reject(TEST_REASON1);
+        Promise<Void> p = JQ.reject(newReason(TEST_REASON1));
 
         BlockingDataHolder<Void> then1 = new BlockingDataHolder<>();
         p.then(new DataFulfilledCallback<Void, Void>(then1));
@@ -140,7 +140,7 @@ public class PromiseTests extends AsyncTests {
         deferred.resolve(TEST_VALUE2);
         assertResolved(p, TEST_VALUE1);
 
-        deferred.reject(TEST_REASON1);
+        deferred.reject(newReason(TEST_REASON1));
         assertResolved(p, TEST_VALUE1);
     }
 
@@ -149,9 +149,9 @@ public class PromiseTests extends AsyncTests {
         final Deferred<String> deferred = JQ.defer();
         Promise<String> p = deferred.promise;
 
-        deferred.reject(TEST_REASON1);
+        deferred.reject(newReason(TEST_REASON1));
 
-        deferred.reject(TEST_REASON2);
+        deferred.reject(newReason(TEST_REASON2));
         assertRejected(p, TEST_REASON1);
 
         deferred.resolve(TEST_VALUE1);
@@ -175,7 +175,7 @@ public class PromiseTests extends AsyncTests {
     public void deferred_isResolvedWithRejectedPromise() throws Exception {
         final Deferred<Integer> deferred = JQ.defer();
         Promise<Integer> p = deferred.promise;
-        Future<Integer> f = JQ.defer(new SlowTask<Integer>(TEST_REASON1, 500));
+        Future<Integer> f = JQ.defer(new SlowTask<Integer>(newReason(TEST_REASON1), 500));
 
         assertPending(p);
         deferred.resolve(f);
@@ -241,7 +241,7 @@ public class PromiseTests extends AsyncTests {
 
     @Test
     public void rejected_isRejectedSync() throws Exception {
-        final Promise<Void> p = JQ.reject(TEST_REASON1);
+        final Promise<Void> p = JQ.reject(newReason(TEST_REASON1));
 
         Exception e = assertThrows(new Callable<Void>() {
             @Override
@@ -250,7 +250,7 @@ public class PromiseTests extends AsyncTests {
             }
         }, ExecutionException.class);
 
-        assertSame(TEST_REASON1, e.getCause());
+        assertEquals(newReason(TEST_REASON1), e.getCause());
     }
 
     @Test
@@ -316,14 +316,14 @@ public class PromiseTests extends AsyncTests {
                     @Override
                     public Future<Integer> onFulfilled(String value) throws Exception {
                         super.onFulfilled(value);
-                        throw TEST_REASON1;
+                        throw newReason(TEST_REASON1);
                     }
                 }).then(
                 new DataFulfilledCallback<>(then2), new DataRejectedCallback<>(fail1));
 
         assertData(then1, 2000, TEST_VALUE1);
         assertNoData(then2, 2000);
-        assertData(fail1, 2000, TEST_REASON1);
+        assertData(fail1, 2000, newReason(TEST_REASON1));
     }
 
     @Test
@@ -355,7 +355,7 @@ public class PromiseTests extends AsyncTests {
                     @Override
                     public Future<Integer> onFulfilled(String value) throws Exception {
                         super.onFulfilled(value);
-                        throw TEST_REASON1;
+                        throw newReason(TEST_REASON1);
                     }
                 }).then(
                 new DataFulfilledCallback<>(then2)).fail(
@@ -363,7 +363,7 @@ public class PromiseTests extends AsyncTests {
 
         assertData(then1, 2000, TEST_VALUE1);
         assertNoData(then2, 2000);
-        assertData(fail1, 2000, TEST_REASON1);
+        assertData(fail1, 2000, newReason(TEST_REASON1));
     }
 
     @Test
@@ -374,7 +374,7 @@ public class PromiseTests extends AsyncTests {
                 new OnFulfilledCallback<String, Void>() {
                     @Override
                     public Future<Void> onFulfilled(String value) throws Exception {
-                        throw TEST_REASON1;
+                        throw newReason(TEST_REASON1);
                     }
                 }).done();
 
@@ -399,9 +399,9 @@ public class PromiseTests extends AsyncTests {
         // new promise is rejected
         BlockingDataHolder<Exception> fail1 = new BlockingDataHolder<>();
 
-        JQ.reject(TEST_REASON1).timeout(1000).fail(new DataRejectedCallback<>(fail1));
+        JQ.reject(newReason(TEST_REASON1)).timeout(1000).fail(new DataRejectedCallback<>(fail1));
 
-        assertData(fail1, 500, TEST_REASON1);
+        assertData(fail1, 500, newReason(TEST_REASON1));
 
     }
 
@@ -425,7 +425,7 @@ public class PromiseTests extends AsyncTests {
     @Test
     public void timeout_isRejectedAfterTimeout() throws InterruptedException {
         // Promise is rejected but too late, TimeoutException is thrown
-        Promise<String> p = JQ.defer(new SlowTask<String>(TEST_REASON1, 2000)).timeout(1000);
+        Promise<String> p = JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 2000)).timeout(1000);
 
         Thread.sleep(500);
         assertPending(p);
@@ -449,7 +449,7 @@ public class PromiseTests extends AsyncTests {
     @Test
     public void delay_isRejected() throws InterruptedException {
         // new promise is rejected immediately
-        Promise<Void> p = JQ.<Void>reject(TEST_REASON1).delay(1000);
+        Promise<Void> p = JQ.<Void>reject(newReason(TEST_REASON1)).delay(1000);
 
         Thread.sleep(500);
         assertRejected(p, TEST_REASON1);
@@ -528,7 +528,7 @@ public class PromiseTests extends AsyncTests {
     @Test
     public void join_isThisRejected() throws InterruptedException {
         // this rejected, that resolved -> new promise should be rejected
-        Promise<String> p1 = JQ.defer(new SlowTask<String>(TEST_REASON1, 0));
+        Promise<String> p1 = JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 0));
         Promise<String> p2 = JQ.resolve(TEST_VALUE1);
         Promise<String> p3 = p1.join(p2);
 
@@ -540,7 +540,7 @@ public class PromiseTests extends AsyncTests {
     public void join_isThatRejected() throws InterruptedException {
         // this resolved, that rejected -> new promise should be rejected
         Promise<String> p1 = JQ.resolve(TEST_VALUE1);
-        Promise<String> p2 = JQ.defer(new SlowTask<String>(TEST_REASON1, 0));
+        Promise<String> p2 = JQ.defer(new SlowTask<String>(newReason(TEST_REASON1), 0));
         Promise<String> p3 = p1.join(p2);
 
         Thread.sleep(500);
@@ -682,7 +682,7 @@ public class PromiseTests extends AsyncTests {
         final BlockingDataHolder<Boolean> fin = new BlockingDataHolder<>();
         final BlockingDataHolder<String> then = new BlockingDataHolder<>();
 
-        JQ.<String>reject(TEST_REASON1).fail(new Promise.OnRejectedCallback<String>() {
+        JQ.<String>reject(newReason(TEST_REASON1)).fail(new Promise.OnRejectedCallback<String>() {
             @Override
             public Future<String> onRejected(Exception reason) throws Exception {
                 return Value.wrap(TEST_VALUE2);
@@ -720,11 +720,11 @@ public class PromiseTests extends AsyncTests {
         }).fin(new Promise.OnFinallyCallback() {
             @Override
             public void onFinally() throws Exception {
-                throw TEST_REASON2;
+                throw newReason(TEST_REASON2);
             }
         }).fail(new DataRejectedCallback<String>(fail));
 
-        assertData(fail, 500, TEST_REASON2);
+        assertData(fail, 500, newReason(TEST_REASON2));
     }
 
     @Test
@@ -746,7 +746,7 @@ public class PromiseTests extends AsyncTests {
         // assert(catchCalled);
         final BlockingDataHolder<Exception> fail = new BlockingDataHolder<>();
 
-        JQ.<String>reject(TEST_REASON1).fail(new Promise.OnRejectedCallback<String>() {
+        JQ.<String>reject(newReason(TEST_REASON1)).fail(new Promise.OnRejectedCallback<String>() {
             @Override
             public Future<String> onRejected(Exception reason) throws Exception {
                 return Value.wrap(TEST_VALUE2);
@@ -754,11 +754,11 @@ public class PromiseTests extends AsyncTests {
         }).fin(new Promise.OnFinallyCallback() {
             @Override
             public void onFinally() throws Exception {
-                throw TEST_REASON2;
+                throw newReason(TEST_REASON2);
             }
         }).fail(new DataRejectedCallback<String>(fail));
 
-        assertData(fail, 500, TEST_REASON2);
+        assertData(fail, 500, newReason(TEST_REASON2));
 
     }
 
@@ -801,10 +801,10 @@ public class PromiseTests extends AsyncTests {
         final BlockingDataHolder<Boolean> fin = new BlockingDataHolder<>();
         final BlockingDataHolder<Exception> fail = new BlockingDataHolder<>();
 
-        JQ.<String>reject(TEST_REASON1).fin(new FinallyCalledCallback(fin)).fail(new DataRejectedCallback<String>(fail));
+        JQ.<String>reject(newReason(TEST_REASON1)).fin(new FinallyCalledCallback(fin)).fail(new DataRejectedCallback<String>(fail));
 
         assertData(fin, 500, true);
-        assertData(fail, 500, TEST_REASON1);
+        assertData(fail, 500, newReason(TEST_REASON1));
     }
 
     @Test
@@ -1035,12 +1035,12 @@ public class PromiseTests extends AsyncTests {
 
     @Test
     public void thenReject() {
-        final Promise<String> p = JQ.resolve(1).thenReject(TEST_REASON1, String.class);
+        final Promise<String> p = JQ.resolve(1).thenReject(newReason(TEST_REASON1), String.class);
         final BlockingDataHolder<Exception> fail1 = new BlockingDataHolder<>();
 
         p.fail(new DataRejectedCallback<String>(fail1));
 
-        assertData(fail1, 2000, TEST_REASON1);
+        assertData(fail1, 2000, newReason(TEST_REASON1));
         assertRejected(p, TEST_REASON1);
     }
 
@@ -1062,7 +1062,7 @@ public class PromiseTests extends AsyncTests {
 
     @Test
     public void tap_isRejected() {
-        final Promise<String> p = JQ.reject(TEST_REASON1);
+        final Promise<String> p = JQ.reject(newReason(TEST_REASON1));
         final BlockingDataHolder<String> tap1 = new BlockingDataHolder<>();
 
         p.tap(new Promise.OnTapCallback<String>() {

--- a/jq/src/test/java/se/code77/jq/PromiseTests.java
+++ b/jq/src/test/java/se/code77/jq/PromiseTests.java
@@ -164,8 +164,8 @@ public class PromiseTests extends AsyncTests {
         Promise<Integer> p = deferred.promise;
         Future<Integer> f = JQ.defer(new SlowTask<>(42, 500));
 
-        deferred.resolve(f);
         assertPending(p);
+        deferred.resolve(f);
 
         Thread.sleep(1000);
         assertResolved(p, 42);
@@ -177,8 +177,8 @@ public class PromiseTests extends AsyncTests {
         Promise<Integer> p = deferred.promise;
         Future<Integer> f = JQ.defer(new SlowTask<Integer>(TEST_REASON1, 500));
 
-        deferred.resolve(f);
         assertPending(p);
+        deferred.resolve(f);
 
         Thread.sleep(1000);
         assertRejected(p, TEST_REASON1);
@@ -190,8 +190,8 @@ public class PromiseTests extends AsyncTests {
         Promise<Integer> p = deferred.promise;
         Future<Integer> f = Value.wrap(42);
 
-        deferred.resolve(f);
         assertPending(p);
+        deferred.resolve(f);
 
         Thread.sleep(1000);
         assertResolved(p, 42);
@@ -204,8 +204,8 @@ public class PromiseTests extends AsyncTests {
         FutureTask<Integer> f = new FutureTask<>(new SlowTask<>(42, 500));
         Executors.newSingleThreadExecutor().execute(f);
 
-        deferred.resolve(f);
         assertPending(p);
+        deferred.resolve(f);
 
         Thread.sleep(1000);
         assertResolved(p, 42);

--- a/jq/src/test/java/se/code77/jq/util/Assert.java
+++ b/jq/src/test/java/se/code77/jq/util/Assert.java
@@ -1,7 +1,5 @@
 package se.code77.jq.util;
 
-import org.junit.rules.Timeout;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
@@ -42,9 +40,15 @@ public class Assert extends org.junit.Assert {
         assertSame(Promise.State.REJECTED, snapshot.state);
         assertNull(snapshot.value);
     }
+
     public static void assertRejected(Promise<?> p, Exception reason) {
         assertRejected(p);
         assertSame(reason, p.inspect().reason);
+    }
+
+    public static void assertRejected(Promise<?> p, String reason) {
+        assertRejected(p);
+        assertSame(reason, p.inspect().reason.getMessage());
     }
 
     public static void assertRejected(Promise<?> p, Class<? extends Exception> reasonClass) {

--- a/jq/src/test/java/se/code77/jq/util/AsyncTests.java
+++ b/jq/src/test/java/se/code77/jq/util/AsyncTests.java
@@ -9,8 +9,24 @@ public class AsyncTests {
     protected static final String TEST_VALUE3 = "JQ";
     protected static final Integer TEST_INTEGER1 = 42;
     protected static final Double TEST_DOUBLE1 = 1.0;
-    protected static final Exception TEST_REASON1 = new IllegalArgumentException("foo");
-    protected static final Exception TEST_REASON2 = new IllegalArgumentException("bar");
+    protected static final String TEST_REASON1 = "Reason 1";
+    protected static final String TEST_REASON2 = "Reason 2";
+
+    private static class TestException extends Exception {
+        public TestException(String message) {
+            super(message);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof TestException &&
+                    ((TestException)o).getMessage().equals(getMessage());
+        }
+    }
+
+    public static Exception newReason(String reason) {
+        return new TestException(reason);
+    }
 
     @Before
     public void setup() {

--- a/jq/src/test/java/se/code77/jq/util/TestConfig.java
+++ b/jq/src/test/java/se/code77/jq/util/TestConfig.java
@@ -18,7 +18,7 @@ public class TestConfig {
             sTestThread = new TestThread("Async event thread");
             sTestThread.start();
 
-            Config config = new Config(false) {
+            Config config = new Config(false, LogLevel.VERBOSE) {
                 @Override
                 public Dispatcher createDispatcher() {
                     Dispatcher d = super.createDispatcher();


### PR DESCRIPTION
Improved debug traces for rejected promises. The source of rejection is dumped to the log, and also where the promise was created, for easier tracking. All this is enabled if log level is at least debug.