### PR TITLE
Add fail method catching only given Exception sub-class

### DIFF
--- a/jq/src/main/java/se/code77/jq/Promise.java
+++ b/jq/src/main/java/se/code77/jq/Promise.java
@@ -142,7 +142,7 @@ public interface Promise<V> extends Future<V> {
      * @param <E> Type of exception to be handled by this rejection handler
      *
      */
-    public interface OnRejectedBaseCallback<NV, E extends Exception> {
+    public interface OnRejectedBaseCallback<E extends Exception, NV> {
         /**
          * The promise on which this callback was registered has been rejected.
          *
@@ -161,7 +161,7 @@ public interface Promise<V> extends Future<V> {
      * @param <NV> Type of the value returned by the callback, which will be
      *            used to resolve the next promise in the chain.
      */
-    public interface OnRejectedCallback<NV> extends OnRejectedBaseCallback<NV, Exception> {
+    public interface OnRejectedCallback<NV> extends OnRejectedBaseCallback<Exception, NV> {
     }
 
     /**
@@ -493,7 +493,7 @@ public interface Promise<V> extends Future<V> {
      *         returned/rejected with the reason thrown from the supplied
      *         callback handler.
      */
-    public <E extends Exception> Promise<V> fail(Class<E> reasonClass, OnRejectedBaseCallback<V, E> onRejected);
+    public <E extends Exception> Promise<V> fail(Class<E> reasonClass, OnRejectedBaseCallback<E, V> onRejected);
 
     /**
      * Observe the progress of this promise by adding a progress callback which

--- a/jq/src/main/java/se/code77/jq/Promise.java
+++ b/jq/src/main/java/se/code77/jq/Promise.java
@@ -135,22 +135,33 @@ public interface Promise<V> extends Future<V> {
     }
 
     /**
-     * Callback interface for rejected promises.
-     * 
+     * Callback interface for rejected promises, handling only a sub-type of Exception.
+     *
      * @param <NV> Type of the value returned by the callback, which will be
      *            used to resolve the next promise in the chain.
+     * @param <E> Type of exception to be handled by this rejection handler
+     *
      */
-    public interface OnRejectedCallback<NV> {
+    public interface OnRejectedBaseCallback<NV, E extends Exception> {
         /**
          * The promise on which this callback was registered has been rejected.
-         * 
+         *
          * @param reason The exception that caused the promise to be rejected.
          * @return A direct value (wrapped in a {@link Value#wrap(Object)}, a
          *         new Promise or any other kind of Future.
          * @throws Exception Any exception thrown by this method will lead to
          *             the rejection of the next promise in the chain.
          */
-        Future<? extends NV> onRejected(Exception reason) throws Exception;
+        Future<? extends NV> onRejected(E reason) throws Exception;
+    }
+
+    /**
+     * Callback interface for rejected promises, catching any Exception.
+     *
+     * @param <NV> Type of the value returned by the callback, which will be
+     *            used to resolve the next promise in the chain.
+     */
+    public interface OnRejectedCallback<NV> extends OnRejectedBaseCallback<NV, Exception> {
     }
 
     /**
@@ -467,6 +478,22 @@ public interface Promise<V> extends Future<V> {
      *         callback handler.
      */
     public Promise<V> fail(OnRejectedCallback<V> onRejected);
+
+    /**
+     * Convenience method for observing the state of this promise by adding a rejection callback which
+     * will be called when the promise is rejected only with a given subclass of Exception.
+     * Analogous to a catch clause in synchronous code.
+     * Note that this method MUST be run on a thread implementing an event loop.
+     *
+     * @see #fail(OnRejectedCallback)
+     * @param <E> sub-type of Exception
+     * @param reasonClass Class of Exception to be caught by the given handler
+     * @param onRejected Rejection handler
+     * @return A new promise that will be resolved with the value
+     *         returned/rejected with the reason thrown from the supplied
+     *         callback handler.
+     */
+    public <E extends Exception> Promise<V> fail(Class<E> reasonClass, OnRejectedBaseCallback<V, E> onRejected);
 
     /**
      * Observe the progress of this promise by adding a progress callback which

--- a/jq/src/main/java/se/code77/jq/PromiseImpl.java
+++ b/jq/src/main/java/se/code77/jq/PromiseImpl.java
@@ -207,6 +207,21 @@ class PromiseImpl<V> implements Promise<V> {
     }
 
     @Override
+    public <E extends Exception> Promise<V> fail(final Class<E> reasonClass, final OnRejectedBaseCallback<V, E> onRejected) {
+        return fail(new OnRejectedCallback<V>() {
+            @Override
+            public Future<? extends V> onRejected(Exception reason) throws Exception {
+                if (reasonClass.isInstance(reason)) {
+                    //noinspection unchecked
+                    return onRejected.onRejected((E)reason);
+                } else {
+                    throw reason;
+                }
+            }
+        });
+    }
+
+    @Override
     public final Promise<V> progress(OnProgressedCallback onProgressed) {
         return addLink(null, null, onProgressed, false);
     }

--- a/jq/src/main/java/se/code77/jq/PromiseImpl.java
+++ b/jq/src/main/java/se/code77/jq/PromiseImpl.java
@@ -207,7 +207,7 @@ class PromiseImpl<V> implements Promise<V> {
     }
 
     @Override
-    public <E extends Exception> Promise<V> fail(final Class<E> reasonClass, final OnRejectedBaseCallback<V, E> onRejected) {
+    public <E extends Exception> Promise<V> fail(final Class<E> reasonClass, final OnRejectedBaseCallback<E, V> onRejected) {
         return fail(new OnRejectedCallback<V>() {
             @Override
             public Future<? extends V> onRejected(Exception reason) throws Exception {

--- a/jq/src/test/java/se/code77/jq/util/AsyncTests.java
+++ b/jq/src/test/java/se/code77/jq/util/AsyncTests.java
@@ -12,7 +12,7 @@ public class AsyncTests {
     protected static final String TEST_REASON1 = "Reason 1";
     protected static final String TEST_REASON2 = "Reason 2";
 
-    private static class TestException extends Exception {
+    public static class TestException extends Exception {
         public TestException(String message) {
             super(message);
         }
@@ -24,7 +24,7 @@ public class AsyncTests {
         }
     }
 
-    public static Exception newReason(String reason) {
+    public static TestException newReason(String reason) {
         return new TestException(reason);
     }
 

--- a/jq/src/test/java/se/code77/jq/util/DataRejectedBaseCallback.java
+++ b/jq/src/test/java/se/code77/jq/util/DataRejectedBaseCallback.java
@@ -1,0 +1,22 @@
+package se.code77.jq.util;
+
+import java.util.concurrent.Future;
+
+import se.code77.jq.Promise;
+import se.code77.jq.Promise.OnRejectedCallback;
+
+public class DataRejectedBaseCallback<E extends Exception, NV> extends DataCallback<E, NV> implements Promise.OnRejectedBaseCallback<NV, E> {
+    public DataRejectedBaseCallback(BlockingDataHolder<E> holder) {
+        super(holder);
+    }
+
+    public DataRejectedBaseCallback(BlockingDataHolder<E> holder, Future<NV> nextValue) {
+        super(holder, nextValue);
+    }
+
+    @Override
+    public Future<NV> onRejected(E reason) throws Exception {
+        mHolder.set(reason);
+        return mNextValue;
+    }
+}

--- a/jq/src/test/java/se/code77/jq/util/DataRejectedBaseCallback.java
+++ b/jq/src/test/java/se/code77/jq/util/DataRejectedBaseCallback.java
@@ -3,9 +3,8 @@ package se.code77.jq.util;
 import java.util.concurrent.Future;
 
 import se.code77.jq.Promise;
-import se.code77.jq.Promise.OnRejectedCallback;
 
-public class DataRejectedBaseCallback<E extends Exception, NV> extends DataCallback<E, NV> implements Promise.OnRejectedBaseCallback<NV, E> {
+public class DataRejectedBaseCallback<E extends Exception, NV> extends DataCallback<E, NV> implements Promise.OnRejectedBaseCallback<E, NV> {
     public DataRejectedBaseCallback(BlockingDataHolder<E> holder) {
         super(holder);
     }

--- a/jq/src/test/java/se/code77/jq/util/DataRejectedCallback.java
+++ b/jq/src/test/java/se/code77/jq/util/DataRejectedCallback.java
@@ -4,18 +4,12 @@ import java.util.concurrent.Future;
 
 import se.code77.jq.Promise.OnRejectedCallback;
 
-public class DataRejectedCallback<NV> extends DataCallback<Exception, NV> implements OnRejectedCallback<NV> {
+public class DataRejectedCallback<NV> extends DataRejectedBaseCallback<Exception, NV> implements OnRejectedCallback<NV> {
     public DataRejectedCallback(BlockingDataHolder<Exception> holder) {
         super(holder);
     }
 
     public DataRejectedCallback(BlockingDataHolder<Exception> holder, Future<NV> nextValue) {
         super(holder, nextValue);
-    }
-
-    @Override
-    public Future<NV> onRejected(Exception reason) throws Exception {
-        mHolder.set(reason);
-        return mNextValue;
     }
 }


### PR DESCRIPTION
Quite frequently a caller wants to catch a specific exception but let others pass through. With fail(Class<? extends Exception>, OnRejectedCallback) this can be accomplished.

Equivalent to catching a specific exception but passing through others in a synchronous try/catch.